### PR TITLE
fix : signup 페이지 supabase 로직 수정

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -72,8 +72,7 @@ export default function SignUpPage() {
     }
     const { data: users, error: insertError } = await supabase
       .from("users")
-      .insert({ email, nickname: "", avatar: "" })
-      .select();
+      .insert({ email });
     // console.log(users, insertError);
 
     alert("회원가입이 완료되었습니다.");

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -4,354 +4,354 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   public: {
     Tables: {
       calendar: {
         Row: {
-          created_at: string
-          id: string
-          medi_name: string
-          medi_time: string
-          side_effect: string
-          user_id: string
-        }
+          created_at: string;
+          id: string;
+          medi_name: string;
+          medi_time: string;
+          side_effect: string;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string
-          id?: string
-          medi_name: string
-          medi_time: string
-          side_effect: string
-          user_id: string
-        }
+          created_at?: string;
+          id?: string;
+          medi_name: string;
+          medi_time: string;
+          side_effect: string;
+          user_id: string;
+        };
         Update: {
-          created_at?: string
-          id?: string
-          medi_name?: string
-          medi_time?: string
-          side_effect?: string
-          user_id?: string
-        }
+          created_at?: string;
+          id?: string;
+          medi_name?: string;
+          medi_time?: string;
+          side_effect?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "calendar_medi_name_fkey"
-            columns: ["medi_name"]
-            isOneToOne: true
-            referencedRelation: "medicine"
-            referencedColumns: ["medi_name"]
+            foreignKeyName: "calendar_medi_name_fkey";
+            columns: ["medi_name"];
+            isOneToOne: true;
+            referencedRelation: "medicine";
+            referencedColumns: ["medi_name"];
           },
           {
-            foreignKeyName: "calendar_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "calendar_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       column: {
         Row: {
-          descriptions: string
-          id: string
-          imgs_url: string
-          subtitle: string
-          title: string
-        }
+          descriptions: string;
+          id: string;
+          imgs_url: string;
+          subtitle: string;
+          title: string;
+        };
         Insert: {
-          descriptions: string
-          id?: string
-          imgs_url: string
-          subtitle: string
-          title: string
-        }
+          descriptions: string;
+          id?: string;
+          imgs_url: string;
+          subtitle: string;
+          title: string;
+        };
         Update: {
-          descriptions?: string
-          id?: string
-          imgs_url?: string
-          subtitle?: string
-          title?: string
-        }
-        Relationships: []
-      }
+          descriptions?: string;
+          id?: string;
+          imgs_url?: string;
+          subtitle?: string;
+          title?: string;
+        };
+        Relationships: [];
+      };
       medicine: {
         Row: {
-          id: string
-          medi_description: string
-          medi_name: string
-        }
+          id: string;
+          medi_description: string;
+          medi_name: string;
+        };
         Insert: {
-          id?: string
-          medi_description: string
-          medi_name: string
-        }
+          id?: string;
+          medi_description: string;
+          medi_name: string;
+        };
         Update: {
-          id?: string
-          medi_description?: string
-          medi_name?: string
-        }
+          id?: string;
+          medi_description?: string;
+          medi_name?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "medicine_medi_name_fkey"
-            columns: ["medi_name"]
-            isOneToOne: true
-            referencedRelation: "pill_alarm"
-            referencedColumns: ["medi_name"]
-          },
-        ]
-      }
+            foreignKeyName: "medicine_medi_name_fkey";
+            columns: ["medi_name"];
+            isOneToOne: true;
+            referencedRelation: "pill_alarm";
+            referencedColumns: ["medi_name"];
+          }
+        ];
+      };
       pill_alarm: {
         Row: {
-          alarm_description: string
-          alarm_name: string
-          alarm_time: string
-          created_at: string
-          id: string
-          medi_name: string
-          user_id: string
-        }
+          alarm_description: string;
+          alarm_name: string;
+          alarm_time: string;
+          created_at: string;
+          id: string;
+          medi_name: string;
+          user_id: string;
+        };
         Insert: {
-          alarm_description: string
-          alarm_name: string
-          alarm_time: string
-          created_at?: string
-          id?: string
-          medi_name?: string
-          user_id: string
-        }
+          alarm_description: string;
+          alarm_name: string;
+          alarm_time: string;
+          created_at?: string;
+          id?: string;
+          medi_name?: string;
+          user_id: string;
+        };
         Update: {
-          alarm_description?: string
-          alarm_name?: string
-          alarm_time?: string
-          created_at?: string
-          id?: string
-          medi_name?: string
-          user_id?: string
-        }
+          alarm_description?: string;
+          alarm_name?: string;
+          alarm_time?: string;
+          created_at?: string;
+          id?: string;
+          medi_name?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "pill_alarm_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "pill_alarm_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       posts: {
         Row: {
-          avatar: string
-          contents: string
-          created_at: string
-          id: string
-          img_url: string
-          nickname: string
-          title: string
-          user_id: string
-        }
+          avatar: string;
+          contents: string;
+          created_at: string;
+          id: string;
+          img_url: string;
+          nickname: string;
+          title: string;
+          user_id: string;
+        };
         Insert: {
-          avatar: string
-          contents: string
-          created_at?: string
-          id?: string
-          img_url: string
-          nickname: string
-          title: string
-          user_id?: string
-        }
+          avatar: string;
+          contents: string;
+          created_at?: string;
+          id?: string;
+          img_url: string;
+          nickname: string;
+          title: string;
+          user_id?: string;
+        };
         Update: {
-          avatar?: string
-          contents?: string
-          created_at?: string
-          id?: string
-          img_url?: string
-          nickname?: string
-          title?: string
-          user_id?: string
-        }
+          avatar?: string;
+          contents?: string;
+          created_at?: string;
+          id?: string;
+          img_url?: string;
+          nickname?: string;
+          title?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "posts_nickname_fkey"
-            columns: ["nickname"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["nickname"]
+            foreignKeyName: "posts_nickname_fkey";
+            columns: ["nickname"];
+            isOneToOne: true;
+            referencedRelation: "users";
+            referencedColumns: ["nickname"];
           },
           {
-            foreignKeyName: "posts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "posts_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       test_posts: {
         Row: {
-          avatar: string
-          contents: string
-          created_at: string
-          id: number
-          img_url: string
-          nickname: string
-          title: string
-          user_id: number
-        }
+          avatar: string;
+          contents: string;
+          created_at: string;
+          id: number;
+          img_url: string;
+          nickname: string;
+          title: string;
+          user_id: number;
+        };
         Insert: {
-          avatar: string
-          contents: string
-          created_at?: string
-          id?: number
-          img_url: string
-          nickname: string
-          title: string
-          user_id: number
-        }
+          avatar: string;
+          contents: string;
+          created_at?: string;
+          id?: number;
+          img_url: string;
+          nickname: string;
+          title: string;
+          user_id: number;
+        };
         Update: {
-          avatar?: string
-          contents?: string
-          created_at?: string
-          id?: number
-          img_url?: string
-          nickname?: string
-          title?: string
-          user_id?: number
-        }
+          avatar?: string;
+          contents?: string;
+          created_at?: string;
+          id?: number;
+          img_url?: string;
+          nickname?: string;
+          title?: string;
+          user_id?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "test_posts_avatar_fkey"
-            columns: ["avatar"]
-            isOneToOne: false
-            referencedRelation: "test_user"
-            referencedColumns: ["avatar"]
+            foreignKeyName: "test_posts_avatar_fkey";
+            columns: ["avatar"];
+            isOneToOne: false;
+            referencedRelation: "test_user";
+            referencedColumns: ["avatar"];
           },
           {
-            foreignKeyName: "test_posts_nickname_fkey"
-            columns: ["nickname"]
-            isOneToOne: false
-            referencedRelation: "test_user"
-            referencedColumns: ["nickname"]
+            foreignKeyName: "test_posts_nickname_fkey";
+            columns: ["nickname"];
+            isOneToOne: false;
+            referencedRelation: "test_user";
+            referencedColumns: ["nickname"];
           },
           {
-            foreignKeyName: "test_posts_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "test_user"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "test_posts_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "test_user";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       test_user: {
         Row: {
-          avatar: string
-          created_at: string
-          email: string
-          id: number
-          nickname: string
-        }
+          avatar: string;
+          created_at: string;
+          email: string;
+          id: number;
+          nickname: string;
+        };
         Insert: {
-          avatar: string
-          created_at?: string
-          email: string
-          id?: number
-          nickname: string
-        }
+          avatar: string;
+          created_at?: string;
+          email: string;
+          id?: number;
+          nickname: string;
+        };
         Update: {
-          avatar?: string
-          created_at?: string
-          email?: string
-          id?: number
-          nickname?: string
-        }
-        Relationships: []
-      }
+          avatar?: string;
+          created_at?: string;
+          email?: string;
+          id?: number;
+          nickname?: string;
+        };
+        Relationships: [];
+      };
       user_medicine: {
         Row: {
-          medicine_id: string
-          user_id: string
-        }
+          medicine_id: string;
+          user_id: string;
+        };
         Insert: {
-          medicine_id?: string
-          user_id: string
-        }
+          medicine_id?: string;
+          user_id: string;
+        };
         Update: {
-          medicine_id?: string
-          user_id?: string
-        }
+          medicine_id?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_medicine_medicine_id_fkey"
-            columns: ["medicine_id"]
-            isOneToOne: false
-            referencedRelation: "medicine"
-            referencedColumns: ["id"]
+            foreignKeyName: "user_medicine_medicine_id_fkey";
+            columns: ["medicine_id"];
+            isOneToOne: false;
+            referencedRelation: "medicine";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "user_medicine_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "user_medicine_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       users: {
         Row: {
-          avatar: string
-          created_at: string
-          email: string
-          id: string
-          nickname: string
-        }
+          avatar: string;
+          created_at: string;
+          email: string;
+          id: string;
+          nickname: string;
+        };
         Insert: {
-          avatar: string
-          created_at?: string
-          email: string
-          id?: string
-          nickname: string
-        }
+          avatar?: string;
+          created_at?: string;
+          email: string;
+          id?: string;
+          nickname?: string;
+        };
         Update: {
-          avatar?: string
-          created_at?: string
-          email?: string
-          id?: string
-          nickname?: string
-        }
+          avatar?: string;
+          created_at?: string;
+          email?: string;
+          id?: string;
+          nickname?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "users_avatar_fkey"
-            columns: ["avatar"]
-            isOneToOne: true
-            referencedRelation: "posts"
-            referencedColumns: ["avatar"]
+            foreignKeyName: "users_avatar_fkey";
+            columns: ["avatar"];
+            isOneToOne: true;
+            referencedRelation: "posts";
+            referencedColumns: ["avatar"];
           },
           {
-            foreignKeyName: "users_id_fkey"
-            columns: ["id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
+            foreignKeyName: "users_id_fkey";
+            columns: ["id"];
+            isOneToOne: true;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+type PublicSchema = Database[Extract<keyof Database, "public">];
 
 export type Tables<
   PublicTableNameOrOptions extends
@@ -360,23 +360,23 @@ export type Tables<
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
         Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never,
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
   : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-        PublicSchema["Views"])
-    ? (PublicSchema["Tables"] &
-        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-        Row: infer R
-      }
-      ? R
-      : never
+      PublicSchema["Views"])
+  ? (PublicSchema["Tables"] &
+      PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+      Row: infer R;
+    }
+    ? R
     : never
+  : never;
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
@@ -384,20 +384,20 @@ export type TablesInsert<
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Insert: infer I
-      }
-      ? I
-      : never
+  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      Insert: infer I;
+    }
+    ? I
     : never
+  : never;
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
@@ -405,20 +405,20 @@ export type TablesUpdate<
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Update: infer U
-      }
-      ? U
-      : never
+  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      Update: infer U;
+    }
+    ? U
     : never
+  : never;
 
 export type Enums<
   PublicEnumNameOrOptions extends
@@ -426,9 +426,9 @@ export type Enums<
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+    : never = never
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-    : never
+  ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+  : never;


### PR DESCRIPTION
## 수정한 코드
- 아바타, 닉네임 타입추론 변경
- signup 페이지 supabase에 users테이블에 email만 넘어오도록 변경

<br>

## 수정 이유
- 회원가입시 nickname, avatar은 supabase에서 Is Nullable로 변경해서 로직에서는 제외함

<br>

## 확인해야 할 사항
- 아직 없음

<br>
