### PR TITLE
Feat/authn

### DIFF
--- a/src/app/(root)/auth/login/page.tsx
+++ b/src/app/(root)/auth/login/page.tsx
@@ -1,17 +1,14 @@
 "use client";
 
 import { useAuthStore } from "@/store/auth";
-import { Tables } from "@/types/supabase";
 import { supabase } from "@/utils/supabase/client";
 import Link from "next/link";
 import { useRef } from "react";
 
-type User = Tables<"users">;
-
 export default function LoginPage() {
   const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
-  const { setUser, setProfile } = useAuthStore();
+  const { setUser } = useAuthStore();
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -23,7 +20,7 @@ export default function LoginPage() {
       return;
     }
 
-    // data 테스트 먼저(성공하면 1번 필요없음 - 성공)
+    // 스키마의 user 정보를 불러오는 로직. try-catch문으로 변경하기
     const { data: authData, error: authError } =
       await supabase.auth.signInWithPassword({
         email: email,
@@ -34,11 +31,8 @@ export default function LoginPage() {
       alert(authError.message);
       return;
     }
-    console.log(authData);
 
-    // Store the auth user data
-    setUser(authData.user);
-
+    // auth스키마의 user테이블의 id 바탕으로 public 스키마의 user테이블에서 유저정보 가져오기
     const { data: userData, error: userError } = await supabase
       .from("users")
       .select("*")
@@ -51,10 +45,8 @@ export default function LoginPage() {
       return;
     }
 
-    console.log(userData.id);
-
-    // Store the user profile data
-    setProfile(userData);
+    // userData를 store에 저장(주스탠드)
+    setUser(userData);
 
     // 1. supabase getUser정보 불러오기 (auth스키마)
     // 2. auth스키마의 user테이블의 id 바탕으로 public 스키마의 user테이블에서 유저정보 가져오기

--- a/src/app/(root)/auth/signup/page.tsx
+++ b/src/app/(root)/auth/signup/page.tsx
@@ -102,7 +102,7 @@ export default function SignUpPage() {
         }
 
         alert("회원가입이 완료되었습니다.");
-        router.replace("/auth/signup/complete");
+        router.replace("/auth/login");
       }
     } catch (error: any) {
       console.error("회원가입 중 에러 발생:", error);

--- a/src/components/molecules/LoginNav.tsx
+++ b/src/components/molecules/LoginNav.tsx
@@ -1,20 +1,48 @@
-"use client";
 import React from "react";
-import TextButton from "../atoms/Textbutton";
+import { useAuthStore } from "@/store/auth";
+import Link from "next/link";
 
-const Navigation = () => {
+interface LoginNavProps {
+  onLogout: () => void;
+}
+
+const LoginNav: React.FC<LoginNavProps> = ({ onLogout }) => {
+  const user = useAuthStore((state) => state.user);
+
   return (
-    <div className="grid grid-cols-3 gap-2">
-      <TextButton text="알림" href="/mypage" />
-      <TextButton text="ㅇㅇㅇ님" href="/columns" />
-      {/*추후 수파베이스 연결 후 입력 바뀌게 설정할꺼임*/}
-      <TextButton text="로그아웃" href="/auth/login" />
-      {/*추후 수파베이스 연결 후 입력 바뀌게 설정할꺼임*/}
+    <div>
+      {user ? (
+        <>
+          <span>환영합니다, {user.email}!</span>
+          <button onClick={onLogout}>로그아웃</button>
+        </>
+      ) : (
+        <Link href="/auth/login">로그인</Link>
+      )}
     </div>
   );
 };
 
-export default Navigation;
+export default LoginNav;
+
+// 원래 코드
+// "use client";
+// import React from "react";
+// import TextButton from "../atoms/Textbutton";
+
+// const Navigation = () => {
+//   return (
+//     <div className="grid grid-cols-3 gap-2">
+//       <TextButton text="알림" href="/mypage" />
+//       <TextButton text="ㅇㅇㅇ님" href="/columns" />
+//       {/*추후 수파베이스 연결 후 입력 바뀌게 설정할꺼임*/}
+//       <TextButton text="로그아웃" href="/auth/login" />
+//       {/*추후 수파베이스 연결 후 입력 바뀌게 설정할꺼임*/}
+//     </div>
+//   );
+// };
+
+// export default Navigation;
 
 // 로그아웃 버튼 onclick 이벤트
 // 주스탠드 스토어 안에 저장되어있는 전역적 관리하는 유저정보 날리는 로직 구현

--- a/src/components/molecules/header.tsx
+++ b/src/components/molecules/header.tsx
@@ -1,19 +1,75 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useAuthStore } from "@/store/auth";
+import { supabase } from "@/utils/supabase/client";
 import LoginNav from "./LoginNav";
 import Navigation from "./navigation";
 import Logo from "../atoms/Logo";
 
 const Header = () => {
+  const { user, setUser, clearAuth } = useAuthStore();
+
+  useEffect(() => {
+    const checkAndSetUser = async () => {
+      if (!user) {
+        const {
+          data: { user: authUser },
+        } = await supabase.auth.getUser();
+
+        if (authUser) {
+          const { data: userData, error } = await supabase
+            .from("users")
+            .select("*")
+            .eq("id", authUser.id)
+            .single();
+
+          if (error) {
+            console.error("Error fetching user data:", error);
+            return;
+          }
+
+          if (userData) {
+            setUser(userData);
+          }
+        }
+      }
+    };
+
+    checkAndSetUser();
+  }, [user, setUser]);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    clearAuth();
+  };
+
   return (
     <header className="flex flex-row items-center justify-between p-4 bg-brand-gray-100 h-[67px]">
       <Logo />
       <Navigation />
-      <LoginNav />
+      <LoginNav onLogout={handleLogout} />
     </header>
   );
 };
 
 export default Header;
+
+// 원래 코드
+// import React from "react";
+// import LoginNav from "./LoginNav";
+// import Navigation from "./navigation";
+// import Logo from "../atoms/Logo";
+
+// const Header = () => {
+//   return (
+//     <header className="flex flex-row items-center justify-between p-4 bg-brand-gray-100 h-[67px]">
+//       <Logo />
+//       <Navigation />
+//       <LoginNav />
+//     </header>
+//   );
+// };
+
+// export default Header;
 
 // 여기서 전역관리 로직작성하기
 // 먼저 useEffect 만들기

--- a/src/components/molecules/header.tsx
+++ b/src/components/molecules/header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect } from "react";
 import { useAuthStore } from "@/store/auth";
 import { supabase } from "@/utils/supabase/client";

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,23 +1,16 @@
-import { create } from "zustand";
-import { User } from "@supabase/supabase-js";
 import { Tables } from "@/types/supabase";
+import { create } from "zustand";
 
-type UserProfile = Tables<"users">;
+type User = Tables<"users">;
 
 interface AuthState {
   user: User | null;
-  profile: UserProfile | null;
   setUser: (user: User | null) => void;
-  setProfile: (profile: UserProfile | null) => void;
   clearAuth: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
-  profile: null,
   setUser: (user) => set({ user }),
-  setProfile: (profile) => set({ profile }),
-  clearAuth: () => set({ user: null, profile: null }),
+  clearAuth: () => set({ user: null }),
 }));
-
-// 주스탠드 사용시 주석해제


### PR DESCRIPTION
## 수정한 코드
-  fix : login 페이지 setProfile 삭제 후 setUser사용으로 변경
- update : LoginNav 페이지 로그아웃기능 구현
- update : 페이지가 로드될 때마다 Header 컴포넌트에서 사용자 인증 상태를 확인하고 주스탠드 스토어를 업데이트

<br>

## 수정 이유
- 주스탠드 스토어 안에 저장되어있는 전역적 관리하는 유저정보 날리는 로직 구현
- Header 컴포넌트에서 전역관리 로직작성하기
  먼저 useEffect 만들기
   1. 주스탠드 안에서 유저정보 없을시 1~4번 로직 최초 1번 실행
     1번 supabase getUser정보 불러오기 (auth스키마)
     2번 auth스키마의 user테이블의 id 바탕으로 public 스키마의 user테이블에서 유저정보 가져오기
    3번 주스탠드 유저정보 저장해놓을 store 만들기
    4번 1번에서 불러온 정보 넣어주기
   
   2. 로그아웃때는 주스탠드 안에서 유저정보 날리기 (로그아웃 버튼)

<br>

## 확인해야 할 사항
- 다시한번 로직구현 재점검 필요

<br>
