### PR TITLE
Feat/authn

### DIFF
--- a/src/app/(root)/auth/complete/page.tsx
+++ b/src/app/(root)/auth/complete/page.tsx
@@ -1,0 +1,39 @@
+// src/app/auth/complete/page.tsx
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+
+const SignupSuccess: React.FC = () => {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <div className="w-[334px] desktop:w-[384px] max-w-md text-center">
+        <h1 className="text-[28px] font-bold text-brand-gray-800 mb-[40px]">
+          회원가입이 완료되었습니다.
+        </h1>
+        <div className="flex justify-between">
+          <button
+            onClick={() => router.push("/")}
+            className="w-[156px] h-[48px] text-[18px] font-semibold rounded-md 
+                       bg-brand-primary-50 text-brand-primary-500 
+                       hover:bg-brand-primary-100 transition-colors duration-300"
+          >
+            홈으로
+          </button>
+          <button
+            onClick={() => router.push("/auth/login")}
+            className="w-[204px] h-[48px] text-[18px] font-semibold rounded-md 
+                       bg-brand-primary-500 text-white 
+                       hover:bg-brand-primary-600 transition-colors duration-300"
+          >
+            로그인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignupSuccess;

--- a/src/app/(root)/auth/signup/page.tsx
+++ b/src/app/(root)/auth/signup/page.tsx
@@ -60,8 +60,8 @@ export default function SignupPage() {
         // 전역 상태에 사용자 정보 저장
         setUser(userData as AuthUser);
 
-        // 회원가입 성공 시 메인 페이지로 이동
-        router.push("/");
+        // 회원가입 성공 시 complete 페이지로 이동
+        router.push("/auth/complete");
       }
     } catch (error) {
       console.error("Signup error:", error);
@@ -79,3 +79,83 @@ export default function SignupPage() {
     </div>
   );
 }
+
+// 기존 코드
+// "use client";
+
+// import React, { useState } from "react";
+// import { useAuthStore, AuthUser } from "@/store/auth";
+// import { supabase } from "@/utils/supabase/client";
+// import { useRouter } from "next/navigation";
+// import { SignupForm } from "@/components/templates/auth/SignupForm";
+
+// export default function SignupPage() {
+//   const { setUser } = useAuthStore();
+//   const router = useRouter();
+//   const [error, setError] = useState<string>("");
+
+//   // 회원가입 처리 함수
+//   const handleSignup = async ({
+//     nickname,
+//     email,
+//     password,
+//     agreeTerms,
+//     agreePrivacy,
+//   }: {
+//     nickname: string;
+//     email: string;
+//     password: string;
+//     agreeTerms: boolean;
+//     agreePrivacy: boolean;
+//   }) => {
+//     try {
+//       // 약관 동의 확인
+//       if (!agreeTerms || !agreePrivacy) {
+//         throw new Error("이용약관과 개인정보 처리방침에 동의해주세요.");
+//       }
+
+//       // Supabase를 통한 회원가입
+//       const { data, error } = await supabase.auth.signUp({
+//         email,
+//         password,
+//         options: {
+//           data: {
+//             name: nickname,
+//           },
+//         },
+//       });
+
+//       if (error) throw error;
+
+//       if (data.user) {
+//         // 저장된 사용자 정보 조회
+//         const { data: userData, error: fetchError } = await supabase
+//           .from("users")
+//           .select("*")
+//           .eq("id", data.user.id)
+//           .single();
+
+//         if (fetchError) throw fetchError;
+
+//         // 전역 상태에 사용자 정보 저장
+//         setUser(userData as AuthUser);
+
+//         // 회원가입 성공 시 메인 페이지로 이동
+//         router.push("/");
+//       }
+//     } catch (error) {
+//       console.error("Signup error:", error);
+//       setError(
+//         error instanceof Error
+//           ? error.message
+//           : "회원가입 중 오류가 발생했습니다."
+//       );
+//     }
+//   };
+
+//   return (
+//     <div className="flex justify-center items-center min-h-screen">
+//       <SignupForm onSubmit={handleSignup} error={error} />
+//     </div>
+//   );
+// }

--- a/src/components/templates/auth/PasswordChangedSuccess.tsx
+++ b/src/components/templates/auth/PasswordChangedSuccess.tsx
@@ -1,0 +1,42 @@
+// src/components/templates/auth/PasswordChangedSuccess.tsx
+
+import React from "react";
+import { useRouter } from "next/navigation";
+
+export const PasswordChangedSuccess: React.FC = () => {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <div className="w-[334px] desktop:w-[384px] max-w-md text-center">
+        {/* 제목 */}
+        <h1 className="text-[28px] font-bold text-brand-gray-800 mb-[40px]">
+          비밀번호 변경이 완료되었습니다.
+        </h1>
+
+        {/* 버튼 컨테이너 */}
+        <div className="flex justify-between">
+          {/* 홈으로 버튼 */}
+          <button
+            onClick={() => router.push("/")}
+            className="w-[156px] h-[48px] text-[18px] font-semibold rounded-md 
+                       bg-brand-primary-50 text-brand-primary-500 
+                       hover:bg-brand-primary-100 transition-colors duration-300"
+          >
+            홈으로
+          </button>
+
+          {/* 로그인 버튼 */}
+          <button
+            onClick={() => router.push("/auth/login")}
+            className="w-[204px] h-[48px] text-[18px] font-semibold rounded-md 
+                       bg-brand-primary-500 text-white 
+                       hover:bg-brand-primary-600 transition-colors duration-300"
+          >
+            로그인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/templates/auth/RecoverPasswordForm.tsx
+++ b/src/components/templates/auth/RecoverPasswordForm.tsx
@@ -1,33 +1,31 @@
 // src/components/templates/auth/RecoverPasswordForm.tsx
+
 "use client";
 
 import React, { useState, useEffect } from "react";
 import { supabase } from "@/utils/supabase/client";
-import { AuthInput } from "@/components/atoms/AuthInput";
-import { AuthButton } from "@/components/atoms/AuthButton";
+import { AuthPasswordInput } from "@/components/molecules/AuthPasswordInput";
 import { useRouter } from "next/navigation";
 
 export const RecoverPasswordForm: React.FC = () => {
   // 상태 관리
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [message, setMessage] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+  const [isPasswordValid, setIsPasswordValid] = useState(false);
+  const [isConfirmPasswordValid, setIsConfirmPasswordValid] = useState(false);
   const router = useRouter();
 
   // 컴포넌트 마운트 시 세션 확인
   useEffect(() => {
     const handlePasswordReset = async () => {
-      // console.log("Starting password reset process");
       const {
         data: { session },
       } = await supabase.auth.getSession();
-      // console.log("Current session:", session);
-
       if (session) {
-        // console.log("Valid session found");
         setMessage("비밀번호를 재설정할 수 있습니다.");
       } else {
-        // console.log("No valid session found");
         setMessage(
           "유효하지 않은 접근입니다. 비밀번호 재설정 이메일을 다시 요청해 주세요."
         );
@@ -38,24 +36,40 @@ export const RecoverPasswordForm: React.FC = () => {
     handlePasswordReset();
   }, []);
 
+  // 비밀번호 유효성 검사
+  useEffect(() => {
+    const hasLetter = /[a-zA-Z]/.test(password);
+    const hasNumber = /\d/.test(password);
+    const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+    const isLongEnough = password.length >= 6;
+    setIsPasswordValid(
+      hasLetter && hasNumber && hasSpecialChar && isLongEnough
+    );
+  }, [password]);
+
+  // 비밀번호 확인 일치 여부 검사
+  useEffect(() => {
+    setIsConfirmPasswordValid(
+      password === confirmPassword && confirmPassword !== ""
+    );
+  }, [password, confirmPassword]);
+
   // 비밀번호 재설정 핸들러
   const handleResetPassword = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Attempting to reset password");
+    if (!isPasswordValid || !isConfirmPasswordValid) {
+      setMessage("비밀번호가 유효하지 않거나 일치하지 않습니다.");
+      return;
+    }
     try {
       const { data, error } = await supabase.auth.updateUser({ password });
       if (error) throw error;
-      console.log("Password reset successful", data);
       setMessage("비밀번호가 성공적으로 재설정되었습니다.");
       // 2초 후 로그인 페이지로 리다이렉트
       setTimeout(() => router.push("/auth/login"), 2000);
     } catch (error) {
       console.error("Password reset error:", error);
-      if (error instanceof Error) {
-        setMessage(`오류: ${error.message}`);
-      } else {
-        setMessage("알 수 없는 오류가 발생했습니다. 다시 시도해 주세요.");
-      }
+      setMessage("비밀번호 재설정 중 오류가 발생했습니다. 다시 시도해 주세요.");
     }
   };
 
@@ -66,26 +80,161 @@ export const RecoverPasswordForm: React.FC = () => {
 
   // 컴포넌트 렌더링
   return (
-    <div className="max-w-md mx-auto mt-8">
-      <h1 className="text-2xl font-bold mb-4">새 비밀번호 설정</h1>
-      {message !== "비밀번호를 재설정할 수 있습니다." ? (
-        <p className="text-center">{message}</p>
-      ) : (
-        <form onSubmit={handleResetPassword}>
-          <AuthInput
-            id="password"
-            name="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="새 비밀번호"
-            required
-          />
-          <AuthButton type="submit" className="w-full mt-4">
-            비밀번호 변경
-          </AuthButton>
-        </form>
-      )}
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="w-[334px] desktop:w-[384px] max-w-md">
+        <h1 className="text-[28px] font-bold text-center text-brand-gray-800 mb-[40px]">
+          비밀번호 재설정
+        </h1>
+        {message !== "비밀번호를 재설정할 수 있습니다." ? (
+          <p className="text-center">{message}</p>
+        ) : (
+          <form onSubmit={handleResetPassword}>
+            {/* 새 비밀번호 입력 필드 */}
+            <div className="mb-4">
+              <AuthPasswordInput
+                id="password"
+                name="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="새 비밀번호 입력"
+                isValid={isPasswordValid || password === ""}
+              />
+              {/* 비밀번호 유효성 검사 메시지 */}
+              {!isPasswordValid && password && (
+                <p className="text-[#F66555] text-[12px] mt-1">
+                  영문자, 숫자, 특수문자 포함하여 최소 6자 이상이어야 합니다.
+                </p>
+              )}
+            </div>
+            {/* 비밀번호 확인 입력 필드 */}
+            <div className="mb-4">
+              <AuthPasswordInput
+                id="confirmPassword"
+                name="confirmPassword"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="비밀번호 확인"
+                isValid={isConfirmPasswordValid || confirmPassword === ""}
+              />
+              {/* 비밀번호 불일치 메시지 */}
+              {!isConfirmPasswordValid && confirmPassword && (
+                <p className="text-[#F66555] text-[12px] mt-1">
+                  비밀번호가 일치하지 않습니다.
+                </p>
+              )}
+              {/* 비밀번호 일치 메시지 */}
+              {isConfirmPasswordValid && confirmPassword && (
+                <p className="text-[#00D37B] text-[12px] mt-1">
+                  비밀번호가 일치합니다.
+                </p>
+              )}
+            </div>
+            {/* 비밀번호 변경 버튼 */}
+            <button
+              type="submit"
+              className={`w-full h-[48px] text-[18px] font-semibold rounded-md transition-colors duration-300 ${
+                isPasswordValid && isConfirmPasswordValid
+                  ? "bg-brand-primary-500 text-white hover:bg-brand-primary-600"
+                  : "bg-brand-gray-200 text-brand-gray-600"
+              }`}
+            >
+              비밀번호 변경
+            </button>
+          </form>
+        )}
+      </div>
     </div>
   );
 };
+
+// 기존 코드
+// "use client";
+
+// import React, { useState, useEffect } from "react";
+// import { supabase } from "@/utils/supabase/client";
+// import { AuthInput } from "@/components/atoms/AuthInput";
+// import { AuthButton } from "@/components/atoms/AuthButton";
+// import { useRouter } from "next/navigation";
+
+// export const RecoverPasswordForm: React.FC = () => {
+//   // 상태 관리
+//   const [password, setPassword] = useState("");
+//   const [message, setMessage] = useState("");
+//   const [isLoading, setIsLoading] = useState(true);
+//   const router = useRouter();
+
+//   // 컴포넌트 마운트 시 세션 확인
+//   useEffect(() => {
+//     const handlePasswordReset = async () => {
+//       // console.log("Starting password reset process");
+//       const {
+//         data: { session },
+//       } = await supabase.auth.getSession();
+//       // console.log("Current session:", session);
+
+//       if (session) {
+//         // console.log("Valid session found");
+//         setMessage("비밀번호를 재설정할 수 있습니다.");
+//       } else {
+//         // console.log("No valid session found");
+//         setMessage(
+//           "유효하지 않은 접근입니다. 비밀번호 재설정 이메일을 다시 요청해 주세요."
+//         );
+//       }
+//       setIsLoading(false);
+//     };
+
+//     handlePasswordReset();
+//   }, []);
+
+//   // 비밀번호 재설정 핸들러
+//   const handleResetPassword = async (e: React.FormEvent) => {
+//     e.preventDefault();
+//     console.log("Attempting to reset password");
+//     try {
+//       const { data, error } = await supabase.auth.updateUser({ password });
+//       if (error) throw error;
+//       console.log("Password reset successful", data);
+//       setMessage("비밀번호가 성공적으로 재설정되었습니다.");
+//       // 2초 후 로그인 페이지로 리다이렉트
+//       setTimeout(() => router.push("/auth/login"), 2000);
+//     } catch (error) {
+//       console.error("Password reset error:", error);
+//       if (error instanceof Error) {
+//         setMessage(`오류: ${error.message}`);
+//       } else {
+//         setMessage("알 수 없는 오류가 발생했습니다. 다시 시도해 주세요.");
+//       }
+//     }
+//   };
+
+//   // 로딩 중 표시
+//   if (isLoading) {
+//     return <div>로딩 중...</div>;
+//   }
+
+//   // 컴포넌트 렌더링
+//   return (
+//     <div className="max-w-md mx-auto mt-8">
+//       <h1 className="text-2xl font-bold mb-4">새 비밀번호 설정</h1>
+//       {message !== "비밀번호를 재설정할 수 있습니다." ? (
+//         <p className="text-center">{message}</p>
+//       ) : (
+//         <form onSubmit={handleResetPassword}>
+//           <AuthInput
+//             id="password"
+//             name="password"
+//             type="password"
+//             value={password}
+//             onChange={(e) => setPassword(e.target.value)}
+//             placeholder="새 비밀번호"
+//             required
+//           />
+//           <AuthButton type="submit" className="w-full mt-4">
+//             비밀번호 변경
+//           </AuthButton>
+//         </form>
+//       )}
+//     </div>
+//   );
+// };

--- a/src/components/templates/auth/RecoverPasswordForm.tsx
+++ b/src/components/templates/auth/RecoverPasswordForm.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect } from "react";
 import { supabase } from "@/utils/supabase/client";
 import { AuthPasswordInput } from "@/components/molecules/AuthPasswordInput";
 import { useRouter } from "next/navigation";
+import { PasswordChangedSuccess } from "./PasswordChangedSuccess";
 
 export const RecoverPasswordForm: React.FC = () => {
   // 상태 관리
@@ -15,6 +16,7 @@ export const RecoverPasswordForm: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isPasswordValid, setIsPasswordValid] = useState(false);
   const [isConfirmPasswordValid, setIsConfirmPasswordValid] = useState(false);
+  const [isPasswordChanged, setIsPasswordChanged] = useState(false);
   const router = useRouter();
 
   // 컴포넌트 마운트 시 세션 확인
@@ -64,9 +66,8 @@ export const RecoverPasswordForm: React.FC = () => {
     try {
       const { data, error } = await supabase.auth.updateUser({ password });
       if (error) throw error;
-      setMessage("비밀번호가 성공적으로 재설정되었습니다.");
-      // 2초 후 로그인 페이지로 리다이렉트
-      setTimeout(() => router.push("/auth/login"), 2000);
+      // 비밀번호 변경 성공 시 상태 업데이트
+      setIsPasswordChanged(true);
     } catch (error) {
       console.error("Password reset error:", error);
       setMessage("비밀번호 재설정 중 오류가 발생했습니다. 다시 시도해 주세요.");
@@ -76,6 +77,11 @@ export const RecoverPasswordForm: React.FC = () => {
   // 로딩 중 표시
   if (isLoading) {
     return <div>로딩 중...</div>;
+  }
+
+  // 비밀번호 변경 성공 시 새로운 컴포넌트 렌더링
+  if (isPasswordChanged) {
+    return <PasswordChangedSuccess />;
   }
 
   // 컴포넌트 렌더링

--- a/src/components/templates/auth/SignupForm.tsx
+++ b/src/components/templates/auth/SignupForm.tsx
@@ -1,10 +1,10 @@
 // 목적: 회원가입 폼의 전체 구조와 로직을 관리하는 컴포넌트
 // src/components/templates/auth/SignupForm.tsx
+
 "use client";
 
 import React, { useState, useEffect } from "react";
 import { AuthInput } from "../../atoms/AuthInput";
-import { AuthButton } from "../../atoms/AuthButton";
 import { AuthPrimaryButton } from "../../atoms/AuthPrimaryButton";
 import { AuthErrorMessage } from "../../atoms/AuthErrorMessage";
 import { AuthPasswordInput } from "../../molecules/AuthPasswordInput";
@@ -12,6 +12,7 @@ import { AuthTermsCheckbox } from "../../molecules/AuthTermsCheckbox";
 import { termsOfService } from "@/constants/termsOfService";
 import { privacyPolicy } from "@/constants/privacyPolicy";
 import { supabase } from "@/utils/supabase/client";
+import { useRouter } from "next/navigation";
 
 type SignupFormProps = {
   onSubmit: (data: {
@@ -20,11 +21,14 @@ type SignupFormProps = {
     password: string;
     agreeTerms: boolean;
     agreePrivacy: boolean;
-  }) => void;
+  }) => Promise<void>;
   error?: string;
 };
 
 export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
+  // 라우터 초기화
+  const router = useRouter();
+
   // 상태 관리
   const [nickname, setNickname] = useState("");
   const [email, setEmail] = useState("");
@@ -44,6 +48,9 @@ export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
   // 이메일 중복 확인 상태
   const [isEmailChecked, setIsEmailChecked] = useState(false);
   const [isEmailAvailable, setIsEmailAvailable] = useState(false);
+
+  // 회원가입 완료 상태
+  const [isSignupComplete, setIsSignupComplete] = useState(false);
 
   // 폼 유효성 검사 함수
   const isFormValid = () => {
@@ -142,10 +149,18 @@ export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
   }, [password, passwordConfirm]);
 
   // 폼 제출 핸들러
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (isFormValid()) {
-      onSubmit({ nickname, email, password, agreeTerms, agreePrivacy });
+      try {
+        // 회원가입 로직 실행
+        await onSubmit({ nickname, email, password, agreeTerms, agreePrivacy });
+        // 회원가입 성공 시 complete 페이지로 이동
+        router.push("/auth/complete");
+      } catch (error) {
+        console.error("Signup error:", error);
+        alert("회원가입 중 오류가 발생했습니다. 다시 시도해 주세요.");
+      }
     } else {
       // 에러 메시지 표시 로직
       let errors = [];
@@ -161,24 +176,38 @@ export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
     }
   };
 
-  // const handleSubmit = (e: React.FormEvent) => {
-  //   e.preventDefault();
-  //   let errors = [];
-  //   if (!nicknameValid) errors.push("닉네임을 확인해주세요.");
-  //   if (!emailValid || !isEmailChecked || !isEmailAvailable)
-  //     errors.push("이메일을 확인해주세요.");
-  //   if (!passwordValid) errors.push("비밀번호를 확인해주세요.");
-  //   if (!passwordConfirmValid)
-  //     errors.push("비밀번호 확인이 일치하지 않습니다.");
-  //   if (!agreeTerms || !agreePrivacy) errors.push("약관에 동의해주세요.");
+  // 회원가입 완료 시 렌더링할 컴포넌트
+  if (isSignupComplete) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen">
+        <div className="w-[334px] desktop:w-[384px] max-w-md text-center">
+          <h1 className="text-[28px] font-bold text-brand-gray-800 mb-[40px]">
+            회원가입이 완료되었습니다.
+          </h1>
+          <div className="flex justify-between">
+            <button
+              onClick={() => router.push("/")}
+              className="w-[156px] h-[48px] text-[18px] font-semibold rounded-md 
+                         bg-brand-primary-50 text-brand-primary-500 
+                         hover:bg-brand-primary-100 transition-colors duration-300"
+            >
+              홈으로
+            </button>
+            <button
+              onClick={() => router.push("/auth/login")}
+              className="w-[204px] h-[48px] text-[18px] font-semibold rounded-md 
+                         bg-brand-primary-500 text-white 
+                         hover:bg-brand-primary-600 transition-colors duration-300"
+            >
+              로그인
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
-  //   if (errors.length > 0) {
-  //     alert(errors.join("\n"));
-  //   } else {
-  //     onSubmit({ nickname, email, password, agreeTerms, agreePrivacy });
-  //   }
-  // };
-
+  // 기존의 회원가입 폼 렌더링
   return (
     <div className="w-[336px] desktop:w-[386px] max-w-md">
       <h2 className="text-[28px] font-bold text-center text-brand-gray-800 mb-6">
@@ -226,7 +255,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
           <div className="flex items-center justify-between">
             <AuthInput
               id="email"
-              name="nickname"
+              name="email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -240,7 +269,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
               <AuthPrimaryButton
                 onClick={handleEmailCheck}
                 className="px-1 ml-[10px]"
-                isActive={emailValid !== true}
+                isActive={emailValid === true}
               >
                 중복확인
               </AuthPrimaryButton>
@@ -351,16 +380,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
         >
           회원가입
         </button>
-        {/* <AuthButton
-          type="submit"
-          className={`w-full text-[18px] font-semibold transition-colors duration-300 ${
-            isFormValid()
-              ? "text-white bg-brand-primary-500 hover:bg-brand-primary-600"
-              : "text-brand-gray-600 bg-brand-gray-200"
-          }`}
-        >
-          회원가입
-        </AuthButton> */}
+
         {/* 에러 메시지 */}
         {error && (
           <p className="mt-4 text-center text-sm text-[#F66555]">{error}</p>
@@ -369,3 +389,374 @@ export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
     </div>
   );
 };
+
+// 기존 코드
+// "use client";
+
+// import React, { useState, useEffect } from "react";
+// import { AuthInput } from "../../atoms/AuthInput";
+// import { AuthButton } from "../../atoms/AuthButton";
+// import { AuthPrimaryButton } from "../../atoms/AuthPrimaryButton";
+// import { AuthErrorMessage } from "../../atoms/AuthErrorMessage";
+// import { AuthPasswordInput } from "../../molecules/AuthPasswordInput";
+// import { AuthTermsCheckbox } from "../../molecules/AuthTermsCheckbox";
+// import { termsOfService } from "@/constants/termsOfService";
+// import { privacyPolicy } from "@/constants/privacyPolicy";
+// import { supabase } from "@/utils/supabase/client";
+
+// type SignupFormProps = {
+//   onSubmit: (data: {
+//     nickname: string;
+//     email: string;
+//     password: string;
+//     agreeTerms: boolean;
+//     agreePrivacy: boolean;
+//   }) => void;
+//   error?: string;
+// };
+
+// export const SignupForm: React.FC<SignupFormProps> = ({ onSubmit, error }) => {
+//   // 상태 관리
+//   const [nickname, setNickname] = useState("");
+//   const [email, setEmail] = useState("");
+//   const [password, setPassword] = useState("");
+//   const [passwordConfirm, setPasswordConfirm] = useState("");
+//   const [agreeTerms, setAgreeTerms] = useState(false);
+//   const [agreePrivacy, setAgreePrivacy] = useState(false);
+
+//   // 유효성 상태 관리
+//   const [nicknameValid, setNicknameValid] = useState<boolean | null>(null);
+//   const [emailValid, setEmailValid] = useState<boolean | null>(null);
+//   const [passwordValid, setPasswordValid] = useState<boolean | null>(null);
+//   const [passwordConfirmValid, setPasswordConfirmValid] = useState<
+//     boolean | null
+//   >(null);
+
+//   // 이메일 중복 확인 상태
+//   const [isEmailChecked, setIsEmailChecked] = useState(false);
+//   const [isEmailAvailable, setIsEmailAvailable] = useState(false);
+
+//   // 폼 유효성 검사 함수
+//   const isFormValid = () => {
+//     return (
+//       nicknameValid === true &&
+//       emailValid === true &&
+//       isEmailChecked &&
+//       isEmailAvailable &&
+//       passwordValid === true &&
+//       passwordConfirmValid === true &&
+//       agreeTerms &&
+//       agreePrivacy
+//     );
+//   };
+
+//   // 이메일 중복 확인 함수
+//   const checkEmail = async (email: string) => {
+//     const { data, error } = await supabase
+//       .from("users")
+//       .select("email")
+//       .eq("email", email);
+
+//     if (error) {
+//       console.error(error.message);
+//       return false;
+//     }
+//     return data.length === 0;
+//   };
+
+//   // 이메일 중복 확인 핸들러
+//   const handleEmailCheck = async () => {
+//     if (!email || !emailValid) {
+//       alert("유효한 이메일을 입력해주세요.");
+//       return;
+//     }
+
+//     const isAvailable = await checkEmail(email);
+//     setIsEmailChecked(true);
+//     setIsEmailAvailable(isAvailable);
+
+//     if (isAvailable) {
+//       alert("사용 가능한 이메일입니다.");
+//     } else {
+//       alert("이미 사용 중인 이메일입니다.");
+//     }
+//   };
+
+//   // 이메일 변경 시 중복 확인 상태 초기화
+//   useEffect(() => {
+//     setIsEmailChecked(false);
+//     setIsEmailAvailable(false);
+//   }, [email]);
+
+//   // 닉네임 유효성 검사
+//   useEffect(() => {
+//     if (nickname !== "") {
+//       setNicknameValid(nickname.length >= 2 && nickname.length <= 6);
+//     } else {
+//       setNicknameValid(null);
+//     }
+//   }, [nickname]);
+
+//   // 이메일 유효성 검사
+//   useEffect(() => {
+//     if (email !== "") {
+//       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+//       setEmailValid(emailRegex.test(email));
+//     } else {
+//       setEmailValid(null);
+//     }
+//   }, [email]);
+
+//   // 비밀번호 유효성 검사
+//   useEffect(() => {
+//     if (password !== "") {
+//       const hasLetter = /[a-zA-Z]/.test(password);
+//       const hasNumber = /\d/.test(password);
+//       const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+//       const isLongEnough = password.length >= 6;
+
+//       setPasswordValid(
+//         hasLetter && hasNumber && hasSpecialChar && isLongEnough
+//       );
+//     } else {
+//       setPasswordValid(null);
+//     }
+//   }, [password]);
+
+//   // 비밀번호 확인 유효성 검사
+//   useEffect(() => {
+//     if (passwordConfirm !== "") {
+//       setPasswordConfirmValid(password === passwordConfirm);
+//     } else {
+//       setPasswordConfirmValid(null);
+//     }
+//   }, [password, passwordConfirm]);
+
+//   // 폼 제출 핸들러
+//   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+//     e.preventDefault();
+//     if (isFormValid()) {
+//       onSubmit({ nickname, email, password, agreeTerms, agreePrivacy });
+//     } else {
+//       // 에러 메시지 표시 로직
+//       let errors = [];
+//       if (!nicknameValid) errors.push("닉네임을 확인해주세요.");
+//       if (!emailValid || !isEmailChecked || !isEmailAvailable)
+//         errors.push("이메일을 확인해주세요.");
+//       if (!passwordValid) errors.push("비밀번호를 확인해주세요.");
+//       if (!passwordConfirmValid)
+//         errors.push("비밀번호 확인이 일치하지 않습니다.");
+//       if (!agreeTerms || !agreePrivacy) errors.push("약관에 동의해주세요.");
+
+//       alert(errors.join("\n"));
+//     }
+//   };
+
+//   // const handleSubmit = (e: React.FormEvent) => {
+//   //   e.preventDefault();
+//   //   let errors = [];
+//   //   if (!nicknameValid) errors.push("닉네임을 확인해주세요.");
+//   //   if (!emailValid || !isEmailChecked || !isEmailAvailable)
+//   //     errors.push("이메일을 확인해주세요.");
+//   //   if (!passwordValid) errors.push("비밀번호를 확인해주세요.");
+//   //   if (!passwordConfirmValid)
+//   //     errors.push("비밀번호 확인이 일치하지 않습니다.");
+//   //   if (!agreeTerms || !agreePrivacy) errors.push("약관에 동의해주세요.");
+
+//   //   if (errors.length > 0) {
+//   //     alert(errors.join("\n"));
+//   //   } else {
+//   //     onSubmit({ nickname, email, password, agreeTerms, agreePrivacy });
+//   //   }
+//   // };
+
+//   return (
+//     <div className="w-[336px] desktop:w-[386px] max-w-md">
+//       <h2 className="text-[28px] font-bold text-center text-brand-gray-800 mb-6">
+//         회원 가입
+//       </h2>
+//       <form onSubmit={handleSubmit} className="space-y-4">
+//         {/* 닉네임 입력 필드 */}
+//         <div>
+//           <label
+//             htmlFor="nickname"
+//             className="block text-[16px] text-brand-gray-1000 mb-1"
+//           >
+//             닉네임
+//           </label>
+//           <AuthInput
+//             id="nickname"
+//             name="nickname"
+//             type="text"
+//             value={nickname}
+//             onChange={(e) => setNickname(e.target.value)}
+//             placeholder="닉네임 설정"
+//             className="w-full px-3 py-2"
+//             isValid={nicknameValid !== false}
+//           />
+//           {nicknameValid === false && (
+//             <p className="text-[#F66555] text-[12px] mt-1">
+//               사용할 수 없는 닉네임입니다.
+//             </p>
+//           )}
+//           {nicknameValid === true && (
+//             <p className="text-[#00D37B] text-[12px] mt-1">
+//               사용할 수 있는 닉네임입니다.
+//             </p>
+//           )}
+//         </div>
+
+//         {/* 이메일 입력 필드 */}
+//         <div>
+//           <label
+//             htmlFor="email"
+//             className="block text-[16px] text-brand-gray-1000 mb-1"
+//           >
+//             이메일 입력
+//           </label>
+//           <div className="flex items-center justify-between">
+//             <AuthInput
+//               id="email"
+//               name="nickname"
+//               type="email"
+//               value={email}
+//               onChange={(e) => setEmail(e.target.value)}
+//               placeholder="example@도메인.com"
+//               className="px-3 py-2 text-brand-gray-1000"
+//               isValid={
+//                 emailValid !== false && (!isEmailChecked || isEmailAvailable)
+//               }
+//             />
+//             <div>
+//               <AuthPrimaryButton
+//                 onClick={handleEmailCheck}
+//                 className="px-1 ml-[10px]"
+//                 isActive={emailValid !== true}
+//               >
+//                 중복확인
+//               </AuthPrimaryButton>
+//             </div>
+//           </div>
+//           {emailValid === false && (
+//             <p className="text-[#F66555] text-[12px] mt-1">
+//               올바른 이메일 형식이 아닙니다.
+//             </p>
+//           )}
+//           {emailValid === true && !isEmailChecked && (
+//             <p className="text-[#F66555] text-[12px] mt-1">
+//               이메일 중복 확인이 필요합니다.
+//             </p>
+//           )}
+//           {isEmailChecked && isEmailAvailable && (
+//             <p className="text-[#00D37B] text-[12px] mt-1">
+//               사용할 수 있는 이메일입니다.
+//             </p>
+//           )}
+//           {isEmailChecked && !isEmailAvailable && (
+//             <p className="text-[#F66555] text-[12px] mt-1">
+//               이미 사용 중인 이메일입니다.
+//             </p>
+//           )}
+//         </div>
+
+//         {/* 비밀번호 입력 필드 */}
+//         <div>
+//           <label
+//             htmlFor="password"
+//             className="block text-[16px] text-brand-gray-1000 mb-1"
+//           >
+//             비밀번호 입력
+//           </label>
+//           <AuthPasswordInput
+//             id="password"
+//             name="password"
+//             value={password}
+//             onChange={(e) => setPassword(e.target.value)}
+//             placeholder="비밀번호를 입력해 주세요."
+//             isValid={passwordValid !== false}
+//           />
+//           {passwordValid === false && (
+//             <p className="text-[#F66555] text-[12px] mt-1">
+//               영문자, 숫자, 특수문자 포함하여 최소 6자 이상이어야 합니다.
+//             </p>
+//           )}
+//         </div>
+
+//         {/* 비밀번호 확인 입력 필드 */}
+//         <div>
+//           <label
+//             htmlFor="passwordConfirm"
+//             className="block text-[16px] text-brand-gray-1000 mb-1"
+//           >
+//             비밀번호 확인
+//           </label>
+//           <AuthPasswordInput
+//             id="passwordConfirm"
+//             name="passwordConfirm"
+//             value={passwordConfirm}
+//             onChange={(e) => setPasswordConfirm(e.target.value)}
+//             placeholder="다시 한번 입력해 주세요."
+//             isValid={passwordConfirmValid !== false}
+//           />
+//           {passwordConfirmValid === false && (
+//             <p className="text-[#F66555] text-[12px] mt-1">
+//               비밀번호가 일치하지 않습니다.
+//             </p>
+//           )}
+//           {passwordConfirmValid === true && (
+//             <p className="text-[#00D37B] text-[12px] mt-1">
+//               비밀번호가 일치합니다.
+//             </p>
+//           )}
+//         </div>
+
+//         {/* 약관 동의 체크박스 */}
+//         <AuthTermsCheckbox
+//           id="agreeTerms"
+//           checked={agreeTerms}
+//           onChange={setAgreeTerms}
+//           label="이용약관 동의 (필수)"
+//           modalTitle="이용약관"
+//           modalContent={termsOfService}
+//         />
+//         <AuthTermsCheckbox
+//           id="agreePrivacy"
+//           checked={agreePrivacy}
+//           onChange={setAgreePrivacy}
+//           label="개인정보 처리방침 동의 (필수)"
+//           modalTitle="개인정보 처리방침"
+//           modalContent={privacyPolicy}
+//         />
+
+//         {/* 에러 메시지 */}
+//         {error && <AuthErrorMessage message={error} />}
+
+//         {/* 회원가입 버튼 */}
+//         <button
+//           type="submit"
+//           className={`w-full h-[48px] text-[18px] font-semibold rounded-md transition-colors duration-300 ${
+//             isFormValid()
+//               ? "!bg-brand-primary-500 !text-white hover:!bg-brand-primary-600"
+//               : "!bg-brand-gray-200 !text-brand-gray-600"
+//           }`}
+//         >
+//           회원가입
+//         </button>
+//         {/* <AuthButton
+//           type="submit"
+//           className={`w-full text-[18px] font-semibold transition-colors duration-300 ${
+//             isFormValid()
+//               ? "text-white bg-brand-primary-500 hover:bg-brand-primary-600"
+//               : "text-brand-gray-600 bg-brand-gray-200"
+//           }`}
+//         >
+//           회원가입
+//         </AuthButton> */}
+//         {/* 에러 메시지 */}
+//         {error && (
+//           <p className="mt-4 text-center text-sm text-[#F66555]">{error}</p>
+//         )}
+//       </form>
+//     </div>
+//   );
+// };


### PR DESCRIPTION
## 수정한 코드
- 비밀번호 재설정 페이지 로직 구현. ui 틀 구성
- 비밀번호 변경 완료시 홈,로그인 새 페이지 생성 후 리다이렉트  로직 구현
- 회원가입 완료시 홈,로그인 새 페이지 생성 후 리다이렉트  로직 구현

<br>

## 수정 이유
- 비밀번호 재설정 페이지 로직 구현. ui 틀 구성
- 비밀번호 변경 완료시 홈,로그인 새 페이지 생성 후 리다이렉트  로직 구현
- 회원가입 완료시 홈,로그인 새 페이지 생성 후 리다이렉트  로직 구현

<br>

## 확인해야 할 사항
- 버튼 리다이렉트 하더라도 헤더에 로그인 상태 유지되어서 수정 필요

<br>
